### PR TITLE
Fix simulation control, thermal-storage physics, timezone handling and example failures

### DIFF
--- a/examples/demo_installation.py
+++ b/examples/demo_installation.py
@@ -8,6 +8,13 @@ Test script to verify that vpplib can be installed and used with the minimal req
 import sys
 import importlib
 
+# Ensure the ✓/✗ status symbols below can be printed on consoles whose default
+# encoding is not UTF-8 (e.g. the Windows cp1252 console).
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+except (AttributeError, ValueError):
+    pass
+
 def test_imports():
     """Test importing key modules from vpplib."""
     modules = [

--- a/tests/test_battery_electric_vehicle_unit.py
+++ b/tests/test_battery_electric_vehicle_unit.py
@@ -1,0 +1,68 @@
+"""Offline unit tests for BatteryElectricVehicle (no DWD/network required).
+
+These complement the integration tests in
+``test_battery_electric_vehicle.py`` and can be run with::
+
+    pytest -m "not integration"
+"""
+
+import random
+
+import pandas as pd
+
+from vpplib.environment import Environment
+from vpplib.battery_electric_vehicle import BatteryElectricVehicle
+
+
+def _make_bev(week_start, week_end, weekend_start, weekend_end):
+    """Build a BEV on a tiny offline environment (no weather data needed)."""
+    env = Environment(
+        timebase=15,
+        start="2020-01-01 00:00:00",
+        end="2020-01-03 23:45:00",
+        time_freq="15 min",
+        surpress_output_globally=True,
+    )
+    return BatteryElectricVehicle(
+        unit="kW",
+        identifier="bev_test",
+        environment=env,
+        battery_max=50,
+        battery_min=10,
+        battery_usage=20,
+        charging_power=11,
+        load_degradation_begin=0.8,
+        charge_efficiency=0.95,
+        week_trip_start=week_start,
+        week_trip_end=week_end,
+        weekend_trip_start=weekend_start,
+        weekend_trip_end=weekend_end,
+    )
+
+
+def test_set_at_home_single_trip_time_does_not_crash():
+    """Regression for point D: randrange(0, len-1) crashed for length-1 lists.
+
+    A single configured trip time previously raised
+    ``ValueError: empty range for randrange()``.
+    """
+    bev = _make_bev(["07:00:00"], ["18:00:00"], ["09:00:00"], ["20:00:00"])
+    bev.prepare_time_series()  # must not raise
+    assert isinstance(bev.timeseries, pd.DataFrame)
+    assert not bev.timeseries.empty
+    assert "at_home" in bev.timeseries.columns
+
+
+def test_set_at_home_can_select_last_trip_index(monkeypatch):
+    """The last trip-time entry must be selectable (old code dropped it)."""
+    # Force randrange to return its maximum valid index for the new single-arg
+    # form randrange(len(x)) -> len(x) - 1.
+    monkeypatch.setattr(random, "randrange", lambda stop: stop - 1)
+    bev = _make_bev(
+        ["07:00:00", "07:30:00"],
+        ["17:00:00", "18:00:00"],
+        ["09:00:00", "09:30:00"],
+        ["19:00:00", "20:00:00"],
+    )
+    bev.prepare_time_series()  # exercises the last index without error
+    assert not bev.timeseries.empty

--- a/tests/test_component_unit.py
+++ b/tests/test_component_unit.py
@@ -1,0 +1,34 @@
+"""Offline unit tests for the timezone-alignment helper.
+
+Run with ``pytest -m "not integration"`` (no DWD/network needed).
+"""
+
+import pandas as pd
+
+from vpplib.component import align_timestamp_tz
+
+
+def test_naive_to_naive_unchanged():
+    ts = align_timestamp_tz("2026-03-01 00:00:00", None)
+    assert ts.tzinfo is None
+    assert ts == pd.Timestamp("2026-03-01 00:00:00")
+
+
+def test_naive_to_aware_localizes_wallclock():
+    ts = align_timestamp_tz("2026-03-01 00:00:00", "Europe/Berlin")
+    assert ts.tzinfo is not None
+    assert ts.tz_localize(None) == pd.Timestamp("2026-03-01 00:00:00")
+
+
+def test_aware_to_naive_keeps_wallclock():
+    aware = pd.Timestamp("2026-03-01 00:00:00", tz="Europe/Berlin")
+    ts = align_timestamp_tz(aware, None)
+    assert ts.tzinfo is None
+    assert ts == pd.Timestamp("2026-03-01 00:00:00")
+
+
+def test_aware_to_aware_keeps_instant():
+    aware = pd.Timestamp("2026-03-01 00:00:00", tz="UTC")
+    ts = align_timestamp_tz(aware, "Europe/Berlin")
+    assert ts.tzinfo is not None
+    assert ts == aware  # same instant, different representation

--- a/tests/test_heating_rod_storage_unit.py
+++ b/tests/test_heating_rod_storage_unit.py
@@ -1,0 +1,50 @@
+"""Offline test for point F: a HeatingRod can charge a ThermalEnergyStorage.
+
+ThermalEnergyStorage.operate_storage expects the snake_case generator API
+(is_running, ramp_up/ramp_down, observations_for_timestamp -> thermal_energy_output).
+HeatingRod historically only offered camelCase; this verifies the compatibility
+layer lets it drive a storage end to end.
+
+Run with ``pytest -m "not integration"`` (no DWD/network needed).
+"""
+
+import pandas as pd
+
+from vpplib.environment import Environment
+from vpplib.heating_rod import HeatingRod
+from vpplib.thermal_energy_storage import ThermalEnergyStorage
+
+
+def test_heating_rod_charges_thermal_storage():
+    env = Environment(
+        timebase=15, start="2020-01-01 00:00:00", end="2020-01-01 23:45:00",
+        time_freq="15 min", surpress_output_globally=True,
+    )
+    idx = pd.date_range(start=env.start, end=env.end, freq=env.time_freq)
+    demand = pd.DataFrame({"thermal_energy_demand": [0.5] * len(idx)}, index=idx)
+
+    hr = HeatingRod(
+        identifier="hr", unit="kW", environment=env, thermal_energy_demand=demand,
+        el_power=5, rampUpTime=1, rampDownTime=1, min_runtime=1, min_stop_time=2,
+        efficiency=0.95,
+    )
+    tes = ThermalEnergyStorage(
+        unit="kW", identifier="tes", environment=env,
+        target_temperature=60, min_temperature=40, hysteresis=5,
+        mass=300, cp=4.18, thermal_energy_loss_per_day=0.13,
+        initial_temperature=50, raise_on_undersupply=False,
+    )
+    # Align both timeseries on the demand index (as a caller would).
+    hr.timeseries = pd.DataFrame(columns=["heat_output", "el_demand"], index=idx)
+    tes.timeseries = pd.DataFrame(columns=["temperature"], index=idx)
+
+    for ts in idx:
+        tes.operate_storage(ts, hr)  # must not raise AttributeError/KeyError
+
+    temps = tes.timeseries["temperature"].astype(float)
+    assert temps.notna().all()
+    assert tes.undersupplied is False
+    assert temps.min() > 40          # never drops below the minimum
+    assert temps.max() > 55          # the rod actually charged the store
+    # log_observation wrote back through the snake wrapper
+    assert hr.timeseries["heat_output"].notna().any()

--- a/tests/test_heating_rod_unit.py
+++ b/tests/test_heating_rod_unit.py
@@ -34,3 +34,25 @@ def test_prepare_time_series_returns_dataframe():
     assert isinstance(result, pd.DataFrame)
     assert isinstance(hr.timeseries, pd.DataFrame)
     assert not hr.timeseries.empty
+
+
+def test_prepare_time_series_handles_tz_aware_demand():
+    """tz audit: slicing a tz-aware timeseries_year with tz-naive env bounds
+    must not raise 'Cannot compare tz-naive and tz-aware datetime-like objects'."""
+    env = Environment(
+        timebase=15, start="2020-01-01 00:00:00", end="2020-01-01 06:00:00",
+        time_freq="15 min", surpress_output_globally=True,
+    )
+    # DWD-derived demand profiles are tz-aware while env.start/end may be naive.
+    idx = pd.date_range(
+        "2020-01-01 00:00:00", "2020-01-01 06:00:00", freq="15min", tz="Europe/Berlin"
+    )
+    demand = pd.DataFrame({"thermal_energy_demand": [1.0] * len(idx)}, index=idx)
+    hr = HeatingRod(
+        identifier="hr", unit="kW", environment=env, thermal_energy_demand=demand,
+        el_power=3, rampUpTime=1, rampDownTime=1, min_runtime=1, min_stop_time=2,
+        efficiency=0.95,
+    )
+    result = hr.prepare_time_series()  # must not raise
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty

--- a/tests/test_heating_rod_unit.py
+++ b/tests/test_heating_rod_unit.py
@@ -1,0 +1,36 @@
+"""Offline unit tests for HeatingRod (point I).
+
+Run with ``pytest -m "not integration"`` (no DWD/network needed).
+"""
+
+import pandas as pd
+
+from vpplib.component import Component
+from vpplib.environment import Environment
+from vpplib.heating_rod import HeatingRod
+
+
+def test_heating_rod_defines_snake_case_prepare():
+    """HeatingRod must not fall back to the base-class stub (sets timeseries=[])."""
+    assert HeatingRod.prepare_time_series is not Component.prepare_time_series
+
+
+def test_prepare_time_series_returns_dataframe():
+    env = Environment(
+        timebase=15,
+        start="2020-01-01 00:00:00",
+        end="2020-01-01 06:00:00",
+        time_freq="15 min",
+        surpress_output_globally=True,
+    )
+    idx = pd.date_range(start=env.start, end=env.end, freq=env.time_freq)
+    demand = pd.DataFrame({"thermal_energy_demand": [1.0] * len(idx)}, index=idx)
+    hr = HeatingRod(
+        identifier="hr", unit="kW", environment=env, thermal_energy_demand=demand,
+        el_power=3, rampUpTime=1, rampDownTime=1, min_runtime=1, min_stop_time=2,
+        efficiency=0.95,
+    )
+    result = hr.prepare_time_series()  # snake_case alias -> prepareTimeSeries
+    assert isinstance(result, pd.DataFrame)
+    assert isinstance(hr.timeseries, pd.DataFrame)
+    assert not hr.timeseries.empty

--- a/tests/test_observations_control_unit.py
+++ b/tests/test_observations_control_unit.py
@@ -1,0 +1,72 @@
+"""Offline unit tests for controlled observations (point B).
+
+``observations_for_timestamp`` must reflect the controlled operation driven by
+``is_running`` and must NOT fall back to a pre-filled (uncontrolled) timeseries
+value — otherwise ``operate_storage`` can never charge the storage.
+
+Run with ``pytest -m "not integration"`` (no DWD/network needed).
+"""
+
+import pandas as pd
+
+from vpplib.environment import Environment
+from vpplib.heat_pump import HeatPump
+from vpplib.heating_rod import HeatingRod
+
+
+def _env_idx():
+    env = Environment(
+        timebase=15,
+        start="2020-01-01 00:00:00",
+        end="2020-01-01 03:00:00",
+        time_freq="15 min",
+        surpress_output_globally=True,
+    )
+    idx = pd.date_range(start=env.start, end=env.end, freq=env.time_freq)
+    return env, idx
+
+
+def test_heat_pump_observation_uses_full_capacity_when_running():
+    env, idx = _env_idx()
+    demand = pd.DataFrame({"thermal_energy_demand": [0.5] * len(idx)}, index=idx)
+    hp = HeatPump(
+        identifier="hp", unit="kW", environment=env, thermal_energy_demand=demand,
+        heat_pump_type="Air", heat_sys_temp=60, el_power=5, th_power=8,
+        ramp_up_time=1, ramp_down_time=1, min_runtime=1, min_stop_time=2,
+    )
+    # Provide temperatures for the on-the-fly COP, and pre-fill the timeseries
+    # row with (uncontrolled) values to prove they are NOT used while running.
+    hp.environment.mean_temp_quarter_hours = pd.DataFrame(
+        {"temperature": [5.0] * len(idx)}, index=idx
+    )
+    hp.timeseries.loc[idx[0]] = [0.5, 3.0, 0.2]  # thermal_energy_output, cop, el_demand
+
+    hp.is_running = True
+    obs = hp.observations_for_timestamp(idx[0])
+    assert obs["el_demand"] == 5  # el_power, not the pre-filled 0.2
+    assert obs["thermal_energy_output"] == 5 * obs["cop"]
+    assert obs["thermal_energy_output"] > 0.5  # not the pre-filled demand value
+
+    hp.is_running = False
+    obs_off = hp.observations_for_timestamp(idx[0])
+    assert obs_off == {"thermal_energy_output": 0, "cop": 0, "el_demand": 0}
+
+
+def test_heating_rod_observation_uses_full_capacity_when_running():
+    env, idx = _env_idx()
+    demand = pd.DataFrame({"thermal_energy_demand": [0.5] * len(idx)}, index=idx)
+    hr = HeatingRod(
+        identifier="hr", unit="kW", environment=env, thermal_energy_demand=demand,
+        el_power=3, rampUpTime=1, rampDownTime=1, min_runtime=1, min_stop_time=2,
+        efficiency=0.95,
+    )
+    hr.timeseries.loc[idx[0]] = [0.5, 0.2]  # heat_output, el_demand (uncontrolled)
+
+    hr.isRunning = True
+    obs = hr.observationsForTimestamp(idx[0])
+    assert obs["el_demand"] == 3  # el_power, not the pre-filled 0.2
+    assert obs["heat_output"] == 3 * 0.95
+
+    hr.isRunning = False
+    obs_off = hr.observationsForTimestamp(idx[0])
+    assert obs_off["el_demand"] == 0 and obs_off["heat_output"] == 0

--- a/tests/test_observations_control_unit.py
+++ b/tests/test_observations_control_unit.py
@@ -52,6 +52,25 @@ def test_heat_pump_observation_uses_full_capacity_when_running():
     assert obs_off == {"thermal_energy_output": 0, "cop": 0, "el_demand": 0}
 
 
+def test_heat_pump_observation_int_timestamp_when_running():
+    """Point J: the integer-timestamp branch must not double-index temperature."""
+    env, idx = _env_idx()
+    demand = pd.DataFrame({"thermal_energy_demand": [0.5] * len(idx)}, index=idx)
+    hp = HeatPump(
+        identifier="hp", unit="kW", environment=env, thermal_energy_demand=demand,
+        heat_pump_type="Air", heat_sys_temp=60, el_power=5, th_power=8,
+        ramp_up_time=1, ramp_down_time=1, min_runtime=1, min_stop_time=2,
+    )
+    hp.environment.mean_temp_quarter_hours = pd.DataFrame(
+        {"temperature": [5.0] * len(idx)}, index=idx
+    )
+    hp.is_running = True
+    obs = hp.observations_for_timestamp(0)  # integer position -> .iloc[0]
+    assert obs["el_demand"] == 5
+    assert obs["cop"] > 0
+    assert obs["thermal_energy_output"] == 5 * obs["cop"]
+
+
 def test_heating_rod_observation_uses_full_capacity_when_running():
     env, idx = _env_idx()
     demand = pd.DataFrame({"thermal_energy_demand": [0.5] * len(idx)}, index=idx)

--- a/tests/test_ramp_logic_unit.py
+++ b/tests/test_ramp_logic_unit.py
@@ -12,6 +12,7 @@ import pandas as pd
 from vpplib.environment import Environment
 from vpplib.heat_pump import HeatPump
 from vpplib.heating_rod import HeatingRod
+from vpplib.combined_heat_and_power import CombinedHeatAndPower
 
 
 def _env_and_demand(hours=6):
@@ -91,3 +92,28 @@ def test_heating_rod_ramp_respects_min_stop_and_run_time():
     assert hr.rampDown(idx[7]) is True
     assert hr.isRunning is False
     assert hr.lastRampDown == idx[7]
+
+
+def test_chp_ramp_respects_min_stop_and_run_time():
+    env, idx, demand = _env_and_demand()
+    chp = CombinedHeatAndPower(
+        thermal_energy_demand=demand, el_power=5, th_power=8,
+        ramp_up_time=1, ramp_down_time=1, min_runtime=2, min_stop_time=3,
+        overall_efficiency=0.9, unit="kW", identifier="chp", environment=env,
+    )
+    assert chp.is_running is False
+    assert chp.last_ramp_up == idx[0] and chp.last_ramp_down == idx[0]
+
+    assert chp.ramp_up(idx[2]) is False
+    assert chp.is_running is False
+
+    assert chp.ramp_up(idx[4]) is True
+    assert chp.is_running is True
+    assert chp.last_ramp_up == idx[4]
+
+    assert chp.ramp_down(idx[5]) is False
+    assert chp.is_running is True
+
+    assert chp.ramp_down(idx[7]) is True
+    assert chp.is_running is False
+    assert chp.last_ramp_down == idx[7]

--- a/tests/test_ramp_logic_unit.py
+++ b/tests/test_ramp_logic_unit.py
@@ -8,6 +8,7 @@ Run with ``pytest -m "not integration"`` (no DWD/network needed).
 """
 
 import pandas as pd
+import pytest
 
 from vpplib.environment import Environment
 from vpplib.heat_pump import HeatPump
@@ -117,3 +118,36 @@ def test_chp_ramp_respects_min_stop_and_run_time():
     assert chp.ramp_down(idx[7]) is True
     assert chp.is_running is False
     assert chp.last_ramp_down == idx[7]
+
+
+def test_ramp_predicates_reject_integer_timestamps():
+    """last_ramp_* are timestamps, so the ramp predicates require a Timestamp."""
+    env, idx, demand = _env_and_demand()
+    hp = HeatPump(
+        identifier="hp", unit="kW", environment=env, thermal_energy_demand=demand,
+        heat_pump_type="Air", heat_sys_temp=60, el_power=5, th_power=8,
+        ramp_up_time=1, ramp_down_time=1, min_runtime=2, min_stop_time=3,
+    )
+    with pytest.raises(TypeError):
+        hp.is_valid_ramp_up(0)
+    with pytest.raises(TypeError):
+        hp.is_valid_ramp_down(0)
+
+    hr = HeatingRod(
+        identifier="hr", unit="kW", environment=env, thermal_energy_demand=demand,
+        el_power=3, rampUpTime=1, rampDownTime=1, min_runtime=2, min_stop_time=3,
+    )
+    with pytest.raises(TypeError):
+        hr.isLegitRampUp(0)
+    with pytest.raises(TypeError):
+        hr.isLegitRampDown(0)
+
+    chp = CombinedHeatAndPower(
+        thermal_energy_demand=demand, el_power=5, th_power=8,
+        ramp_up_time=1, ramp_down_time=1, min_runtime=2, min_stop_time=3,
+        overall_efficiency=0.9, unit="kW", identifier="chp", environment=env,
+    )
+    with pytest.raises(TypeError):
+        chp.is_valid_ramp_up(0)
+    with pytest.raises(TypeError):
+        chp.is_valid_ramp_down(0)

--- a/tests/test_ramp_logic_unit.py
+++ b/tests/test_ramp_logic_unit.py
@@ -1,0 +1,93 @@
+"""Offline unit tests for the ramp control logic (point A).
+
+Verifies that the ramp validators are side-effect-free predicates and that
+``ramp_up``/``ramp_down`` update ``last_ramp_up``/``last_ramp_down`` so that
+``min_runtime``/``min_stop_time`` are actually enforced.
+
+Run with ``pytest -m "not integration"`` (no DWD/network needed).
+"""
+
+import pandas as pd
+
+from vpplib.environment import Environment
+from vpplib.heat_pump import HeatPump
+from vpplib.heating_rod import HeatingRod
+
+
+def _env_and_demand(hours=6):
+    env = Environment(
+        timebase=15,
+        start="2020-01-01 00:00:00",
+        end=f"2020-01-01 {hours:02d}:00:00",
+        time_freq="15 min",
+        surpress_output_globally=True,
+    )
+    idx = pd.date_range(start=env.start, end=env.end, freq=env.time_freq)
+    demand = pd.DataFrame({"thermal_energy_demand": [1.0] * len(idx)}, index=idx)
+    return env, idx, demand
+
+
+def test_heat_pump_ramp_respects_min_stop_and_run_time():
+    env, idx, demand = _env_and_demand()
+    hp = HeatPump(
+        identifier="hp", unit="kW", environment=env, thermal_energy_demand=demand,
+        heat_pump_type="Air", heat_sys_temp=60, el_power=5, th_power=8,
+        ramp_up_time=1, ramp_down_time=1, min_runtime=2, min_stop_time=3,
+    )
+    assert hp.is_running is False
+    assert hp.last_ramp_up == idx[0] and hp.last_ramp_down == idx[0]
+
+    # Too early: min_stop_time (3 steps) not yet elapsed since last_ramp_down.
+    assert hp.ramp_up(idx[2]) is False
+    assert hp.is_running is False
+
+    # After min_stop_time elapsed -> may switch on; last_ramp_up updated.
+    assert hp.ramp_up(idx[4]) is True
+    assert hp.is_running is True
+    assert hp.last_ramp_up == idx[4]
+
+    # Too early to switch off: min_runtime (2 steps) not yet elapsed.
+    assert hp.ramp_down(idx[5]) is False
+    assert hp.is_running is True
+
+    # After min_runtime elapsed -> may switch off; last_ramp_down updated.
+    assert hp.ramp_down(idx[7]) is True
+    assert hp.is_running is False
+    assert hp.last_ramp_down == idx[7]
+
+
+def test_heat_pump_validators_are_pure_predicates():
+    env, idx, demand = _env_and_demand()
+    hp = HeatPump(
+        identifier="hp", unit="kW", environment=env, thermal_energy_demand=demand,
+        heat_pump_type="Air", heat_sys_temp=60, el_power=5, th_power=8,
+        ramp_up_time=1, ramp_down_time=1, min_runtime=2, min_stop_time=3,
+    )
+    before = hp.is_running
+    result = hp.is_valid_ramp_up(idx[4])
+    assert isinstance(result, bool)
+    assert hp.is_running == before  # no side effect
+
+
+def test_heating_rod_ramp_respects_min_stop_and_run_time():
+    env, idx, demand = _env_and_demand()
+    hr = HeatingRod(
+        identifier="hr", unit="kW", environment=env, thermal_energy_demand=demand,
+        el_power=3, rampUpTime=1, rampDownTime=1, min_runtime=2, min_stop_time=3,
+    )
+    assert hr.isRunning is False
+    assert hr.lastRampUp == idx[0] and hr.lastRampDown == idx[0]
+
+    assert hr.rampUp(idx[2]) is False
+    assert hr.isRunning is False
+
+    assert hr.rampUp(idx[4]) is True
+    assert hr.isRunning is True
+    assert hr.lastRampUp == idx[4]
+
+    assert hr.rampDown(idx[5]) is False
+    assert hr.isRunning is True
+
+    assert hr.rampDown(idx[7]) is True
+    assert hr.isRunning is False
+    assert hr.lastRampDown == idx[7]

--- a/tests/test_thermal_energy_storage_unit.py
+++ b/tests/test_thermal_energy_storage_unit.py
@@ -1,7 +1,11 @@
-"""Offline unit tests for ThermalEnergyStorage (point G).
+"""Offline unit tests for ThermalEnergyStorage (points G and E).
 
 Run with ``pytest -m "not integration"`` (no DWD/network needed).
 """
+
+import logging
+
+import pytest
 
 from vpplib.environment import Environment
 from vpplib.thermal_energy_storage import ThermalEnergyStorage
@@ -17,7 +21,7 @@ def _env():
     )
 
 
-def _tes(initial_temperature=None):
+def _tes(initial_temperature=None, raise_on_undersupply=True):
     return ThermalEnergyStorage(
         target_temperature=60,
         min_temperature=40,
@@ -29,6 +33,7 @@ def _tes(initial_temperature=None):
         identifier="tes",
         environment=_env(),
         initial_temperature=initial_temperature,
+        raise_on_undersupply=raise_on_undersupply,
     )
 
 
@@ -42,3 +47,21 @@ def test_initial_temperature_sets_consistent_soc():
     tes = _tes(initial_temperature=50)
     assert tes.current_temperature == 50
     assert tes.state_of_charge == 300 * 4.18 * (50 + 273.15)
+
+
+def test_undersupply_raises_by_default():
+    tes = _tes()
+    tes.current_temperature = 39.0  # below min_temperature (40)
+    with pytest.raises(ValueError):
+        tes.get_needs_loading()
+    assert tes.undersupplied is True
+
+
+def test_undersupply_soft_mode_warns_and_continues(caplog):
+    tes = _tes(raise_on_undersupply=False)
+    tes.current_temperature = 39.0
+    with caplog.at_level(logging.WARNING):
+        result = tes.get_needs_loading()  # must not raise
+    assert tes.undersupplied is True
+    assert result is True  # still needs loading
+    assert "too low" in caplog.text.lower()

--- a/tests/test_thermal_energy_storage_unit.py
+++ b/tests/test_thermal_energy_storage_unit.py
@@ -1,0 +1,44 @@
+"""Offline unit tests for ThermalEnergyStorage (point G).
+
+Run with ``pytest -m "not integration"`` (no DWD/network needed).
+"""
+
+from vpplib.environment import Environment
+from vpplib.thermal_energy_storage import ThermalEnergyStorage
+
+
+def _env():
+    return Environment(
+        timebase=15,
+        start="2020-01-01 00:00:00",
+        end="2020-01-01 06:00:00",
+        time_freq="15 min",
+        surpress_output_globally=True,
+    )
+
+
+def _tes(initial_temperature=None):
+    return ThermalEnergyStorage(
+        target_temperature=60,
+        min_temperature=40,
+        hysteresis=5,
+        mass=300,
+        cp=4.18,
+        thermal_energy_loss_per_day=0.13,
+        unit="kW",
+        identifier="tes",
+        environment=_env(),
+        initial_temperature=initial_temperature,
+    )
+
+
+def test_default_start_temperature_unchanged():
+    tes = _tes()
+    assert tes.current_temperature == 60 - 5  # target - hysteresis
+    assert tes.state_of_charge == 300 * 4.18 * ((60 - 5) + 273.15)
+
+
+def test_initial_temperature_sets_consistent_soc():
+    tes = _tes(initial_temperature=50)
+    assert tes.current_temperature == 50
+    assert tes.state_of_charge == 300 * 4.18 * (50 + 273.15)

--- a/tests/test_thermal_energy_storage_unit.py
+++ b/tests/test_thermal_energy_storage_unit.py
@@ -37,16 +37,26 @@ def _tes(initial_temperature=None, raise_on_undersupply=True):
     )
 
 
+def _usable_kwh(temp, mass=300, cp=4.18, ambient=20.0):
+    """Usable energy above ambient in kWh (matches the model in point C)."""
+    return mass * cp * (temp - ambient) / 3600.0
+
+
 def test_default_start_temperature_unchanged():
     tes = _tes()
     assert tes.current_temperature == 60 - 5  # target - hysteresis
-    assert tes.state_of_charge == 300 * 4.18 * ((60 - 5) + 273.15)
+    assert tes.state_of_charge == _usable_kwh(60 - 5)
 
 
 def test_initial_temperature_sets_consistent_soc():
     tes = _tes(initial_temperature=50)
     assert tes.current_temperature == 50
-    assert tes.state_of_charge == 300 * 4.18 * (50 + 273.15)
+    assert tes.state_of_charge == _usable_kwh(50)
+
+
+def test_state_of_charge_round_trips_to_temperature():
+    tes = _tes(initial_temperature=52)
+    assert tes._temperature_from_energy(tes.state_of_charge) == 52
 
 
 def test_undersupply_raises_by_default():

--- a/tests/test_user_profile_unit.py
+++ b/tests/test_user_profile_unit.py
@@ -1,0 +1,47 @@
+"""Offline unit tests for UserProfile.get_consumerfactor (point H).
+
+Calibrating the consumerfactor on a window much shorter than a year scales the
+demand so the short window carries the full yearly demand. The library now warns
+about that. Run with ``pytest -m "not integration"`` (no DWD/network needed).
+"""
+
+import logging
+
+import pandas as pd
+
+from vpplib.user_profile import UserProfile
+
+
+def _profile_with_hdel(n_days, consumerfactor=None):
+    """Build a UserProfile with only the attributes get_consumerfactor needs."""
+    up = UserProfile.__new__(UserProfile)
+    up.consumerfactor = consumerfactor
+    up.thermal_energy_demand_yearly = 12500
+    up.h_del = pd.DataFrame(
+        {"h_del": [1.0] * n_days},
+        index=pd.date_range("2020-01-01", periods=n_days, freq="D"),
+    )
+    return up
+
+
+def test_short_window_warns(caplog):
+    up = _profile_with_hdel(7)
+    with caplog.at_level(logging.WARNING):
+        cf = up.get_consumerfactor()
+    assert cf == 12500 / 7
+    assert "calibrated on only 7 day" in caplog.text
+
+
+def test_full_year_does_not_warn(caplog):
+    up = _profile_with_hdel(365)
+    with caplog.at_level(logging.WARNING):
+        up.get_consumerfactor()
+    assert "calibrated on only" not in caplog.text
+
+
+def test_supplied_consumerfactor_is_kept_and_silent(caplog):
+    up = _profile_with_hdel(7, consumerfactor=0.5)
+    with caplog.at_level(logging.WARNING):
+        cf = up.get_consumerfactor()
+    assert cf == 0.5  # not recomputed
+    assert "calibrated on only" not in caplog.text

--- a/vpplib/battery_electric_vehicle.py
+++ b/vpplib/battery_electric_vehicle.py
@@ -363,28 +363,20 @@ class BatteryElectricVehicle(Component):
         for hour, weekday in zip(self.hour, self.weekday):
             if (hour == "00:00:00") & (weekday < 5):
                 departure = self.week_trip_start[
-                    random.randrange(
-                        0, (len(self.week_trip_start) - 1), 1
-                    )
+                    random.randrange(len(self.week_trip_start))
                 ]
 
                 arrival = self.week_trip_end[
-                    random.randrange(
-                        0, (len(self.week_trip_end) - 1), 1
-                    )
+                    random.randrange(len(self.week_trip_end))
                 ]
 
             elif (hour == "00:00:00") & (weekday >= 5):
                 departure = self.weekend_trip_start[
-                    random.randrange(
-                        0, (len(self.weekend_trip_start) - 1), 1
-                    )
+                    random.randrange(len(self.weekend_trip_start))
                 ]
 
                 arrival = self.weekend_trip_end[
-                    random.randrange(
-                        0, (len(self.weekend_trip_end) - 1), 1
-                    )
+                    random.randrange(len(self.weekend_trip_end))
                 ]
 
             if (hour > arrival) | (hour < departure):

--- a/vpplib/combined_heat_and_power.py
+++ b/vpplib/combined_heat_and_power.py
@@ -201,21 +201,19 @@ class CombinedHeatAndPower(Component):
 
         Returns
         -------
-        self.is_running = True, if ramp up is valid
-        self.is_running = False, if ramp up is not valid
+        bool
+            True if the minimum stop time has elapsed since the last ramp down
+            (i.e. the chp may be switched on), otherwise False.
 
         """
 
         if isinstance(timestamp, int):
-            self.is_running = timestamp - self.last_ramp_down > self.min_stop_time
-        else:
-            timestamp = self._normalize_timestamp(timestamp)
-            self.is_running = (
-                self.last_ramp_down + self.min_stop_time * self.timeseries.index.freq
-                < timestamp
-            )
-
-        return self.is_running
+            return timestamp - self.last_ramp_down > self.min_stop_time
+        timestamp = self._normalize_timestamp(timestamp)
+        return (
+            self.last_ramp_down + self.min_stop_time * self.timeseries.index.freq
+            < timestamp
+        )
 
     def is_valid_ramp_down(self, timestamp):
 
@@ -231,21 +229,19 @@ class CombinedHeatAndPower(Component):
 
         Returns
         -------
-        self.is_running = False, if ramp down is valid
-        self.is_running = True, if ramp down is not valid
+        bool
+            True if the minimum runtime has elapsed since the last ramp up
+            (i.e. the chp may be switched off), otherwise False.
 
         """
 
         if isinstance(timestamp, int):
-            self.is_running = not (timestamp - self.last_ramp_up > self.min_runtime)
-        else:
-            timestamp = self._normalize_timestamp(timestamp)
-            self.is_running = not (
-                self.last_ramp_up + self.min_runtime * self.timeseries.index.freq
-                < timestamp
-            )
-
-        return self.is_running
+            return timestamp - self.last_ramp_up > self.min_runtime
+        timestamp = self._normalize_timestamp(timestamp)
+        return (
+            self.last_ramp_up + self.min_runtime * self.timeseries.index.freq
+            < timestamp
+        )
 
     def ramp_up(self, timestamp):
 
@@ -270,12 +266,13 @@ class CombinedHeatAndPower(Component):
 
         if self.is_running:
             return None
-        else:
-            if self.is_valid_ramp_up(timestamp):
-                self.is_running = True
-                return True
-            else:
-                return False
+        if self.is_valid_ramp_up(timestamp):
+            self.is_running = True
+            if not isinstance(timestamp, int):
+                timestamp = self._normalize_timestamp(timestamp)
+            self.last_ramp_up = timestamp
+            return True
+        return False
 
     def ramp_down(self, timestamp):
 
@@ -300,12 +297,13 @@ class CombinedHeatAndPower(Component):
 
         if not self.is_running:
             return None
-        else:
-            if self.is_valid_ramp_down(timestamp):
-                self.is_running = False
-                return True
-            else:
-                return False
+        if self.is_valid_ramp_down(timestamp):
+            self.is_running = False
+            if not isinstance(timestamp, int):
+                timestamp = self._normalize_timestamp(timestamp)
+            self.last_ramp_down = timestamp
+            return True
+        return False
 
     # =========================================================================
     # Balancing Functions

--- a/vpplib/combined_heat_and_power.py
+++ b/vpplib/combined_heat_and_power.py
@@ -264,9 +264,8 @@ class CombinedHeatAndPower(Component):
             return None
         if self.is_valid_ramp_up(timestamp):
             self.is_running = True
-            if not isinstance(timestamp, int):
-                timestamp = self._normalize_timestamp(timestamp)
-            self.last_ramp_up = timestamp
+            # is_valid_ramp_up already rejected ints, so timestamp is a Timestamp.
+            self.last_ramp_up = self._normalize_timestamp(timestamp)
             return True
         return False
 
@@ -295,9 +294,8 @@ class CombinedHeatAndPower(Component):
             return None
         if self.is_valid_ramp_down(timestamp):
             self.is_running = False
-            if not isinstance(timestamp, int):
-                timestamp = self._normalize_timestamp(timestamp)
-            self.last_ramp_down = timestamp
+            # is_valid_ramp_down already rejected ints, so timestamp is a Timestamp.
+            self.last_ramp_down = self._normalize_timestamp(timestamp)
             return True
         return False
 

--- a/vpplib/combined_heat_and_power.py
+++ b/vpplib/combined_heat_and_power.py
@@ -207,9 +207,7 @@ class CombinedHeatAndPower(Component):
 
         """
 
-        if isinstance(timestamp, int):
-            return timestamp - self.last_ramp_down > self.min_stop_time
-        timestamp = self._normalize_timestamp(timestamp)
+        timestamp = self._require_timestamp(timestamp)
         return (
             self.last_ramp_down + self.min_stop_time * self.timeseries.index.freq
             < timestamp
@@ -235,9 +233,7 @@ class CombinedHeatAndPower(Component):
 
         """
 
-        if isinstance(timestamp, int):
-            return timestamp - self.last_ramp_up > self.min_runtime
-        timestamp = self._normalize_timestamp(timestamp)
+        timestamp = self._require_timestamp(timestamp)
         return (
             self.last_ramp_up + self.min_runtime * self.timeseries.index.freq
             < timestamp

--- a/vpplib/component.py
+++ b/vpplib/component.py
@@ -15,7 +15,12 @@ def align_timestamp_tz(timestamp, index_tz):
 
     Handles every combination of tz-naive and tz-aware inputs so that ``.loc[]``
     slicing and value lookups do not raise "Cannot compare tz-naive and tz-aware
-    datetime-like objects". Wall-clock time is preserved.
+    datetime-like objects".
+
+    A tz-naive input is interpreted as wall-clock time in ``index_tz`` (its
+    wall-clock value is kept). A tz-aware input that is converted to a different
+    timezone keeps the same instant, so its wall-clock representation changes
+    accordingly.
 
     Parameters
     ----------
@@ -91,6 +96,19 @@ class Component(object):
         if idx_tz is not None and ts.tzinfo is None:
             ts = ts.tz_localize(idx_tz)
         return ts
+
+    def _require_timestamp(self, timestamp):
+        """Normalize a timestamp for ramp predicates, rejecting integers.
+
+        The ramp predicates compare against ``last_ramp_*``, which are stored as
+        pandas Timestamps, so positional integer timestamps cannot be used here.
+        """
+        if isinstance(timestamp, int):
+            raise TypeError(
+                "ramp predicates require a pandas.Timestamp; integer (positional) "
+                "timestamps are not supported because last_ramp_* are timestamps."
+            )
+        return self._normalize_timestamp(timestamp)
 
     def value_for_timestamp(self, timestamp):
         """Get the component's value for a specific timestamp.

--- a/vpplib/component.py
+++ b/vpplib/component.py
@@ -10,6 +10,30 @@ like photovoltaic systems, energy storage, heat pumps, etc.
 import pandas as pd
 
 
+def align_timestamp_tz(timestamp, index_tz):
+    """Return ``timestamp`` adjusted to match a target index timezone.
+
+    Handles every combination of tz-naive and tz-aware inputs so that ``.loc[]``
+    slicing and value lookups do not raise "Cannot compare tz-naive and tz-aware
+    datetime-like objects". Wall-clock time is preserved.
+
+    Parameters
+    ----------
+    timestamp : str or datetime-like
+        The timestamp (or slice bound) to align.
+    index_tz : tzinfo or None
+        The timezone of the target index (``index.tz``); ``None`` for tz-naive.
+
+    Returns
+    -------
+    pandas.Timestamp
+    """
+    ts = pd.Timestamp(timestamp)
+    if index_tz is not None:
+        return ts.tz_localize(index_tz) if ts.tzinfo is None else ts.tz_convert(index_tz)
+    return ts.tz_localize(None) if ts.tzinfo is not None else ts
+
+
 class Component(object):
     """Base class for all components in a virtual power plant.
     

--- a/vpplib/heat_pump.py
+++ b/vpplib/heat_pump.py
@@ -430,10 +430,10 @@ class HeatPump(Component):
         
         Parameters
         ----------
-        timestamp : int or pandas._libs.tslibs.timestamps.Timestamp
-            The current time at which to check if ramp up is allowed. Can be an integer (e.g., seconds since epoch)
-            or a pandas Timestamp.
-            
+        timestamp : pandas.Timestamp
+            The current time. Integer (positional) timestamps are not supported,
+            because ``last_ramp_*`` are stored as timestamps.
+
         Returns
         -------
         bool
@@ -442,20 +442,16 @@ class HeatPump(Component):
 
         Raises
         ------
-        ValueError
-            If `timestamp` is not of type int or pandas._libs.tslibs.timestamps.Timestamp.
-            
+        TypeError
+            If `timestamp` is an int instead of a pandas.Timestamp.
+
         Notes
         -----
-        - For integer timestamps, checks if the difference between the current timestamp and `last_ramp_down` 
-          exceeds `min_stop_time`.
-        - For pandas Timestamps, checks if the sum of `last_ramp_down` and the minimum stop time (scaled by the 
-          timeseries frequency) is less than the current timestamp.
+        Checks whether ``last_ramp_down`` plus the minimum stop time (scaled by the
+        timeseries frequency) is earlier than the current timestamp.
         """
 
-        if isinstance(timestamp, int):
-            return timestamp - self.last_ramp_down > self.min_stop_time
-        timestamp = self._normalize_timestamp(timestamp)
+        timestamp = self._require_timestamp(timestamp)
         return (
             self.last_ramp_down + self.min_stop_time * self.timeseries.index.freq
             < timestamp
@@ -467,9 +463,10 @@ class HeatPump(Component):
         
         Parameters
         ----------
-        timestamp : int or pandas._libs.tslibs.timestamps.Timestamp
-            The current time, either as an integer (e.g., seconds since epoch) or as a pandas Timestamp.
-            
+        timestamp : pandas.Timestamp
+            The current time. Integer (positional) timestamps are not supported,
+            because ``last_ramp_*`` are stored as timestamps.
+
         Returns
         -------
         bool
@@ -478,17 +475,15 @@ class HeatPump(Component):
 
         Raises
         ------
-        ValueError
-            If `timestamp` is not of type int or pandas._libs.tslibs.timestamps.Timestamp.
+        TypeError
+            If `timestamp` is an int instead of a pandas.Timestamp.
 
         Notes
         -----
         This predicate has no side effects; ``ramp_down`` updates the state.
         """
 
-        if isinstance(timestamp, int):
-            return timestamp - self.last_ramp_up > self.min_runtime
-        timestamp = self._normalize_timestamp(timestamp)
+        timestamp = self._require_timestamp(timestamp)
         return (
             self.last_ramp_up + self.min_runtime * self.timeseries.index.freq
             < timestamp

--- a/vpplib/heat_pump.py
+++ b/vpplib/heat_pump.py
@@ -436,10 +436,10 @@ class HeatPump(Component):
             
         Returns
         -------
-        None
-            Updates the `is_running` attribute of the instance based on whether the minimum stop time has elapsed
-            since the last ramp down.
-            
+        bool
+            True if the minimum stop time has elapsed since the last ramp down
+            (i.e. the heat pump may be switched on), otherwise False.
+
         Raises
         ------
         ValueError
@@ -454,13 +454,12 @@ class HeatPump(Component):
         """
 
         if isinstance(timestamp, int):
-            self.is_running = timestamp - self.last_ramp_down > self.min_stop_time
-        else:
-            timestamp = self._normalize_timestamp(timestamp)
-            self.is_running = (
-                self.last_ramp_down + self.min_stop_time * self.timeseries.index.freq
-                < timestamp
-            )
+            return timestamp - self.last_ramp_down > self.min_stop_time
+        timestamp = self._normalize_timestamp(timestamp)
+        return (
+            self.last_ramp_down + self.min_stop_time * self.timeseries.index.freq
+            < timestamp
+        )
 
     def is_valid_ramp_down(self, timestamp):
         """
@@ -473,26 +472,27 @@ class HeatPump(Component):
             
         Returns
         -------
-        None
-        
+        bool
+            True if the minimum runtime has elapsed since the last ramp up
+            (i.e. the heat pump may be switched off), otherwise False.
+
         Raises
         ------
         ValueError
             If `timestamp` is not of type int or pandas._libs.tslibs.timestamps.Timestamp.
-            
+
         Notes
         -----
-        This method updates the `is_running` attribute based on whether the minimum runtime has elapsed since the last ramp up.
+        This predicate has no side effects; ``ramp_down`` updates the state.
         """
 
         if isinstance(timestamp, int):
-            self.is_running = not (timestamp - self.last_ramp_up > self.min_runtime)
-        else:
-            timestamp = self._normalize_timestamp(timestamp)
-            self.is_running = not (
-                self.last_ramp_up + self.min_runtime * self.timeseries.index.freq
-                < timestamp
-            )
+            return timestamp - self.last_ramp_up > self.min_runtime
+        timestamp = self._normalize_timestamp(timestamp)
+        return (
+            self.last_ramp_up + self.min_runtime * self.timeseries.index.freq
+            < timestamp
+        )
 
     def ramp_up(self, timestamp):
         """
@@ -519,12 +519,13 @@ class HeatPump(Component):
 
         if self.is_running:
             return None
-        else:
-            if self.is_valid_ramp_up(timestamp):
-                self.is_running = True
-                return True
-            else:
-                return False
+        if self.is_valid_ramp_up(timestamp):
+            self.is_running = True
+            if not isinstance(timestamp, int):
+                timestamp = self._normalize_timestamp(timestamp)
+            self.last_ramp_up = timestamp
+            return True
+        return False
 
     def ramp_down(self, timestamp):
         """
@@ -546,9 +547,10 @@ class HeatPump(Component):
 
         if not self.is_running:
             return None
-        else:
-            if self.is_valid_ramp_down(timestamp):
-                self.is_running = False
-                return True
-            else:
-                return False
+        if self.is_valid_ramp_down(timestamp):
+            self.is_running = False
+            if not isinstance(timestamp, int):
+                timestamp = self._normalize_timestamp(timestamp)
+            self.last_ramp_down = timestamp
+            return True
+        return False

--- a/vpplib/heat_pump.py
+++ b/vpplib/heat_pump.py
@@ -378,31 +378,29 @@ class HeatPump(Component):
         all values are set to zero.
         """
 
+        # The observation reflects the *controlled* operation: when the heat pump
+        # is running it draws el_power and delivers el_power * COP, otherwise zero.
+        # It must NOT fall back to a pre-filled (uncontrolled) timeseries value,
+        # which would make operate_storage unable to charge the storage.
         if isinstance(timestamp, int):
-            if pd.isna(next(iter(self.timeseries.iloc[timestamp]))) == False:
-                thermal_energy_output, cop, el_demand = self.timeseries.iloc[timestamp]
+            if self.is_running:
+                el_demand = self.el_power
+                temp = self.environment.mean_temp_quarter_hours.temperature.iloc[
+                    timestamp
+                ]["temperature"]
+                cop = self.get_current_cop(temp)
+                thermal_energy_output = el_demand * cop
             else:
-                if self.is_running:
-                    el_demand = self.el_power
-                    temp = self.environment.mean_temp_quarter_hours.temperature.iloc[
-                        timestamp
-                    ]["temperature"]
-                    cop = self.get_current_cop(temp)
-                    thermal_energy_output = el_demand * cop
-                else:
-                    el_demand, cop, thermal_energy_output = 0, 0, 0
+                el_demand, cop, thermal_energy_output = 0, 0, 0
         else:
             timestamp = self._normalize_timestamp(timestamp)
-            if pd.isna(next(iter(self.timeseries.loc[timestamp]))) == False:
-                thermal_energy_output, cop, el_demand = self.timeseries.loc[timestamp]
+            if self.is_running:
+                el_demand = self.el_power
+                temp = self.environment.mean_temp_quarter_hours.temperature.loc[timestamp]
+                cop = self.get_current_cop(temp)
+                thermal_energy_output = el_demand * cop
             else:
-                if self.is_running:
-                    el_demand = self.el_power
-                    temp = self.environment.mean_temp_quarter_hours.temperature.loc[timestamp]
-                    cop = self.get_current_cop(temp)
-                    thermal_energy_output = el_demand * cop
-                else:
-                    el_demand, cop, thermal_energy_output = 0, 0, 0
+                el_demand, cop, thermal_energy_output = 0, 0, 0
 
         observations = {
             "thermal_energy_output": thermal_energy_output,

--- a/vpplib/heat_pump.py
+++ b/vpplib/heat_pump.py
@@ -6,7 +6,7 @@ This file contains the basic functionalities of the HeatPump class.
 import datetime
 
 import pandas as pd
-from .component import Component
+from .component import Component, align_timestamp_tz
 
 
 class HeatPump(Component):
@@ -255,8 +255,10 @@ class HeatPump(Component):
         ):
             self.get_timeseries_year()
 
+        index_tz = self.timeseries_year.index.tz
         self.timeseries = self.timeseries_year.loc[
-            self.environment.start : self.environment.end
+            align_timestamp_tz(self.environment.start, index_tz):
+            align_timestamp_tz(self.environment.end, index_tz)
         ]
 
         return self.timeseries

--- a/vpplib/heat_pump.py
+++ b/vpplib/heat_pump.py
@@ -387,7 +387,7 @@ class HeatPump(Component):
                 el_demand = self.el_power
                 temp = self.environment.mean_temp_quarter_hours.temperature.iloc[
                     timestamp
-                ]["temperature"]
+                ]
                 cop = self.get_current_cop(temp)
                 thermal_energy_output = el_demand * cop
             else:

--- a/vpplib/heat_pump.py
+++ b/vpplib/heat_pump.py
@@ -516,9 +516,8 @@ class HeatPump(Component):
             return None
         if self.is_valid_ramp_up(timestamp):
             self.is_running = True
-            if not isinstance(timestamp, int):
-                timestamp = self._normalize_timestamp(timestamp)
-            self.last_ramp_up = timestamp
+            # is_valid_ramp_up already rejected ints, so timestamp is a Timestamp.
+            self.last_ramp_up = self._normalize_timestamp(timestamp)
             return True
         return False
 
@@ -544,8 +543,7 @@ class HeatPump(Component):
             return None
         if self.is_valid_ramp_down(timestamp):
             self.is_running = False
-            if not isinstance(timestamp, int):
-                timestamp = self._normalize_timestamp(timestamp)
-            self.last_ramp_down = timestamp
+            # is_valid_ramp_down already rejected ints, so timestamp is a Timestamp.
+            self.last_ramp_down = self._normalize_timestamp(timestamp)
             return True
         return False

--- a/vpplib/heating_rod.py
+++ b/vpplib/heating_rod.py
@@ -395,8 +395,42 @@ class HeatingRod(Component):
         """
         self.timeseries.loc[timestamp, "heat_output"] = observation["heat_output"]
         self.timeseries.loc[timestamp, "el_demand"] = observation["el_demand"]
-        
+
         return self.timeseries
+
+    # =========================================================================
+    # snake_case compatibility layer
+    # -------------------------------------------------------------------------
+    # HeatingRod historically uses camelCase (isRunning, rampUp, ...) and returns
+    # 'heat_output' from its observation, whereas ThermalEnergyStorage.operate_storage
+    # expects the same snake_case API as HeatPump / CombinedHeatAndPower
+    # (is_running, ramp_up/ramp_down, observations_for_timestamp -> thermal_energy_output).
+    # These thin wrappers let a HeatingRod charge a ThermalEnergyStorage directly.
+    # =========================================================================
+    @property
+    def is_running(self):
+        return self.isRunning
+
+    @is_running.setter
+    def is_running(self, value):
+        self.isRunning = value
+
+    def ramp_up(self, timestamp):
+        return self.rampUp(timestamp)
+
+    def ramp_down(self, timestamp):
+        return self.rampDown(timestamp)
+
+    def observations_for_timestamp(self, timestamp):
+        """snake_case wrapper around :meth:`observationsForTimestamp`.
+
+        Adds the ``thermal_energy_output`` key (equal to ``heat_output``) that
+        ``ThermalEnergyStorage.operate_storage`` expects.
+        """
+        observations = self.observationsForTimestamp(timestamp)
+        observations["thermal_energy_output"] = observations["heat_output"]
+        return observations
+
     #%% ramping functions
     
     

--- a/vpplib/heating_rod.py
+++ b/vpplib/heating_rod.py
@@ -17,7 +17,7 @@ Key features:
 import datetime
 
 import pandas as pd
-from .component import Component
+from .component import Component, align_timestamp_tz
 
 class HeatingRod(Component):
     """
@@ -233,7 +233,11 @@ class HeatingRod(Component):
         if pd.isna(next(iter(self.timeseries_year.heat_output))) == True:
             self.get_timeseries_year()
         
-        self.timeseries = self.timeseries_year.loc[self.environment.start:self.environment.end]
+        index_tz = self.timeseries_year.index.tz
+        self.timeseries = self.timeseries_year.loc[
+            align_timestamp_tz(self.environment.start, index_tz):
+            align_timestamp_tz(self.environment.end, index_tz)
+        ]
 
         return self.timeseries
 

--- a/vpplib/heating_rod.py
+++ b/vpplib/heating_rod.py
@@ -419,18 +419,18 @@ class HeatingRod(Component):
         ValueError
             If the timestamp is not of a supported type.
             
-        Notes
-        -----
-        This method updates the isRunning attribute based on the check result.
+        Returns
+        -------
+        bool
+            True if the minimum stop time has elapsed since the last ramp down.
         """
         if isinstance(timestamp, int):
-            self.isRunning = timestamp - self.lastRampDown > self.min_stop_time
-        else:
-            timestamp = self._normalize_timestamp(timestamp)
-            self.isRunning = (
-                self.lastRampDown + self.min_stop_time * self.timeseries.index.freq
-                < timestamp
-            )
+            return timestamp - self.lastRampDown > self.min_stop_time
+        timestamp = self._normalize_timestamp(timestamp)
+        return (
+            self.lastRampDown + self.min_stop_time * self.timeseries.index.freq
+            < timestamp
+        )
 
     def isLegitRampDown(self, timestamp):
         """
@@ -448,19 +448,19 @@ class HeatingRod(Component):
         ValueError
             If the timestamp is not of a supported type.
             
-        Notes
-        -----
-        This method updates the isRunning attribute based on the check result.
+        Returns
+        -------
+        bool
+            True if the minimum runtime has elapsed since the last ramp up.
         """
         if isinstance(timestamp, int):
-            self.isRunning = not (timestamp - self.lastRampUp > self.min_runtime)
-        else:
-            timestamp = self._normalize_timestamp(timestamp)
-            self.isRunning = not (
-                self.lastRampUp + self.min_runtime * self.timeseries.index.freq
-                < timestamp
-            )
-        
+            return timestamp - self.lastRampUp > self.min_runtime
+        timestamp = self._normalize_timestamp(timestamp)
+        return (
+            self.lastRampUp + self.min_runtime * self.timeseries.index.freq
+            < timestamp
+        )
+
     def rampUp(self, timestamp):
         """
         Attempt to ramp up the heating rod at the given timestamp.
@@ -479,12 +479,13 @@ class HeatingRod(Component):
         """
         if self.isRunning:
             return None
-        else:
-            if self.isLegitRampUp(timestamp):
-                self.isRunning = True
-                return True
-            else: 
-                return False
+        if self.isLegitRampUp(timestamp):
+            self.isRunning = True
+            if not isinstance(timestamp, int):
+                timestamp = self._normalize_timestamp(timestamp)
+            self.lastRampUp = timestamp
+            return True
+        return False
 
 
     def rampDown(self, timestamp):
@@ -505,9 +506,10 @@ class HeatingRod(Component):
         """
         if not self.isRunning:
             return None
-        else:
-            if self.isLegitRampDown(timestamp):
-                self.isRunning = False
-                return True
-            else: 
-                return False
+        if self.isLegitRampDown(timestamp):
+            self.isRunning = False
+            if not isinstance(timestamp, int):
+                timestamp = self._normalize_timestamp(timestamp)
+            self.lastRampDown = timestamp
+            return True
+        return False

--- a/vpplib/heating_rod.py
+++ b/vpplib/heating_rod.py
@@ -514,9 +514,8 @@ class HeatingRod(Component):
             return None
         if self.isLegitRampUp(timestamp):
             self.isRunning = True
-            if not isinstance(timestamp, int):
-                timestamp = self._normalize_timestamp(timestamp)
-            self.lastRampUp = timestamp
+            # isLegitRampUp already rejected ints, so timestamp is a Timestamp.
+            self.lastRampUp = self._normalize_timestamp(timestamp)
             return True
         return False
 
@@ -541,8 +540,7 @@ class HeatingRod(Component):
             return None
         if self.isLegitRampDown(timestamp):
             self.isRunning = False
-            if not isinstance(timestamp, int):
-                timestamp = self._normalize_timestamp(timestamp)
-            self.lastRampDown = timestamp
+            # isLegitRampDown already rejected ints, so timestamp is a Timestamp.
+            self.lastRampDown = self._normalize_timestamp(timestamp)
             return True
         return False

--- a/vpplib/heating_rod.py
+++ b/vpplib/heating_rod.py
@@ -446,22 +446,21 @@ class HeatingRod(Component):
         
         Parameters
         ----------
-        timestamp : int or pandas.Timestamp
-            The timestamp at which to check if ramping up is legitimate.
-            
+        timestamp : pandas.Timestamp
+            The timestamp at which to check. Integer (positional) timestamps are
+            not supported, because ``lastRampDown`` is stored as a timestamp.
+
         Raises
         ------
-        ValueError
-            If the timestamp is not of a supported type.
-            
+        TypeError
+            If `timestamp` is an int instead of a pandas.Timestamp.
+
         Returns
         -------
         bool
             True if the minimum stop time has elapsed since the last ramp down.
         """
-        if isinstance(timestamp, int):
-            return timestamp - self.lastRampDown > self.min_stop_time
-        timestamp = self._normalize_timestamp(timestamp)
+        timestamp = self._require_timestamp(timestamp)
         return (
             self.lastRampDown + self.min_stop_time * self.timeseries.index.freq
             < timestamp
@@ -475,22 +474,21 @@ class HeatingRod(Component):
         
         Parameters
         ----------
-        timestamp : int or pandas.Timestamp
-            The timestamp at which to check if ramping down is legitimate.
-            
+        timestamp : pandas.Timestamp
+            The timestamp at which to check. Integer (positional) timestamps are
+            not supported, because ``lastRampUp`` is stored as a timestamp.
+
         Raises
         ------
-        ValueError
-            If the timestamp is not of a supported type.
-            
+        TypeError
+            If `timestamp` is an int instead of a pandas.Timestamp.
+
         Returns
         -------
         bool
             True if the minimum runtime has elapsed since the last ramp up.
         """
-        if isinstance(timestamp, int):
-            return timestamp - self.lastRampUp > self.min_runtime
-        timestamp = self._normalize_timestamp(timestamp)
+        timestamp = self._require_timestamp(timestamp)
         return (
             self.lastRampUp + self.min_runtime * self.timeseries.index.freq
             < timestamp

--- a/vpplib/heating_rod.py
+++ b/vpplib/heating_rod.py
@@ -352,36 +352,25 @@ class HeatingRod(Component):
         ValueError
             If the timestamp is not of a supported type.
         """
+        # The observation reflects the *controlled* operation: when running the
+        # heating rod draws el_power and delivers el_power * efficiency, otherwise
+        # zero. It must NOT fall back to a pre-filled (uncontrolled) timeseries
+        # value, which would make operate_storage unable to charge the storage.
         if isinstance(timestamp, int):
-
-            if pd.isna(next(iter(self.timeseries.iloc[timestamp]))) == False:
-
-                heat_output, el_demand = self.timeseries.iloc[timestamp]
+            if self.isRunning:
+                el_demand = self.el_power
                 efficiency = self.efficiency
-
+                heat_output = el_demand * efficiency
             else:
-
-                if self.isRunning:
-                    el_demand = self.el_power
-                    temp = self.environment.mean_temp_quarter_hours.temperature.iloc[timestamp]
-                    efficiency = self.efficiency
-                    heat_output = el_demand * efficiency
-                else:
-                    el_demand, efficiency, heat_output = 0, 0, 0
-
+                el_demand, efficiency, heat_output = 0, 0, 0
         else:
             timestamp = self._normalize_timestamp(timestamp)
-            if pd.isna(next(iter(self.timeseries.loc[timestamp]))) == False:
-                heat_output, el_demand = self.timeseries.loc[timestamp]
+            if self.isRunning:
+                el_demand = self.el_power
                 efficiency = self.efficiency
+                heat_output = el_demand * efficiency
             else:
-                if self.isRunning:
-                    el_demand = self.el_power
-                    temp = self.environment.mean_temp_quarter_hours.temperature.loc[timestamp]
-                    efficiency = self.efficiency
-                    heat_output = el_demand * efficiency
-                else:
-                    el_demand, efficiency, heat_output = 0, 0, 0
+                el_demand, efficiency, heat_output = 0, 0, 0
         
         observations = {'heat_output':heat_output, 
                         'efficiency':efficiency, 'el_demand':el_demand}

--- a/vpplib/heating_rod.py
+++ b/vpplib/heating_rod.py
@@ -234,9 +234,17 @@ class HeatingRod(Component):
             self.get_timeseries_year()
         
         self.timeseries = self.timeseries_year.loc[self.environment.start:self.environment.end]
-        
+
         return self.timeseries
-    
+
+    def prepare_time_series(self):
+        """snake_case alias for :meth:`prepareTimeSeries`.
+
+        Without this, a snake_case call would hit the base-class stub in
+        ``component.py`` and set ``self.timeseries`` to an empty list.
+        """
+        return self.prepareTimeSeries()
+
     def get_timeseries_year(self):
         """
         Generate the annual time series for heat output and electrical demand.

--- a/vpplib/operator.py
+++ b/vpplib/operator.py
@@ -22,6 +22,8 @@ import pandapower as pp
 import matplotlib.pyplot as plt
 from tqdm.auto import tqdm
 
+from vpplib.component import align_timestamp_tz
+
 
 class Operator(object):
     """
@@ -281,14 +283,17 @@ class Operator(object):
                     == "baseload"
                 ):
 
+                    bus_series = baseload[
+                        str(
+                            self.net.load.loc[
+                                self.net.load.name == name, 'bus'
+                            ].item()
+                        )
+                    ]
+                    # The baseload index may be tz-naive while idx (from a
+                    # component timeseries) is tz-aware, or vice versa.
                     self.net.load.loc[self.net.load.name == name, 'p_mw'] = (
-                        baseload[
-                            str(
-                                self.net.load.loc[
-                                    self.net.load.name == name, 'bus'
-                                ].item()
-                            )
-                        ][idx]
+                        bus_series[align_timestamp_tz(idx, bus_series.index.tz)]
                         / 1000000
                     )
                     self.net.load.loc[self.net.load.name == name, 'q_mvar'] = 0

--- a/vpplib/photovoltaic.py
+++ b/vpplib/photovoltaic.py
@@ -8,7 +8,7 @@ The Photovoltaic class inherits from the Component class and implements methods
 for preparing time series data, limiting power output, and retrieving observations.
 """
 
-from vpplib.component import Component
+from vpplib.component import Component, align_timestamp_tz
 
 import datetime
 import pandas as pd
@@ -205,19 +205,19 @@ class Photovoltaic(Component):
         if len(self.environment.pv_data) == 0:
             raise ValueError("self.environment.pv_data is empty.")
 
-        if 'poa_global' in self.environment.pv_data.columns:
-            
-            self.modelchain.run_model_from_poa(
-                data=self.environment.pv_data.loc[
-                    self.environment.start: self.environment.end
-                ],
-            )
+        # Align the slice bounds with the weather-data index timezone. Depending
+        # on the Environment configuration ``start``/``end`` may be tz-naive while
+        # the DWD weather data is tz-aware (or vice versa), which would otherwise
+        # raise "Cannot compare tz-naive and tz-aware datetime-like objects".
+        pv_data = self.environment.pv_data
+        start = align_timestamp_tz(self.environment.start, pv_data.index.tz)
+        end = align_timestamp_tz(self.environment.end, pv_data.index.tz)
+        weather = pv_data.loc[start:end]
+
+        if 'poa_global' in pv_data.columns:
+            self.modelchain.run_model_from_poa(data=weather)
         else:
-            self.modelchain.run_model(
-                weather=self.environment.pv_data.loc[
-                    self.environment.start: self.environment.end
-                ],
-            )
+            self.modelchain.run_model(weather=weather)
 
         timeseries = pd.DataFrame(
             self.modelchain.results.ac / 1000)  # convert to kW

--- a/vpplib/thermal_energy_storage.py
+++ b/vpplib/thermal_energy_storage.py
@@ -42,7 +42,7 @@ class ThermalEnergyStorage(Component):
     cp : float
         Specific heat capacity of the storage medium in J/(kg·K)
     state_of_charge : float
-        Current thermal energy content of the storage in Joules
+        Usable thermal energy stored above ``ambient_temperature``, in kWh
     thermal_energy_loss_per_day : float
         Fraction of thermal energy lost per day (e.g., 0.1 for 10% loss)
     efficiency_per_timestep : float
@@ -65,6 +65,7 @@ class ThermalEnergyStorage(Component):
         identifier=None,
         environment=None,
         initial_temperature=None,
+        ambient_temperature=20.0,
         raise_on_undersupply=True,
     ):
         """
@@ -94,6 +95,10 @@ class ThermalEnergyStorage(Component):
             Start temperature in °C. If None (default), the storage starts at
             ``target_temperature - hysteresis``. The state of charge is derived
             from the resulting current temperature, so both stay consistent.
+        ambient_temperature : float, optional
+            Reference temperature in °C for the *usable* stored energy
+            (default 20). ``state_of_charge`` is the energy stored above this
+            temperature and the standby loss acts on it.
         raise_on_undersupply : bool, optional
             If True (default), ``get_needs_loading`` raises ``ValueError`` when the
             temperature drops below ``min_temperature`` (backwards compatible). If
@@ -136,7 +141,9 @@ class ThermalEnergyStorage(Component):
         self.hysteresis = hysteresis
         self.mass = mass
         self.cp = cp
-        self.state_of_charge = mass * cp * (self.current_temperature + 273.15)
+        self.ambient_temperature = ambient_temperature
+        # state_of_charge is the usable thermal energy above ambient, in kWh.
+        self.state_of_charge = self._energy_from_temperature(self.current_temperature)
         # Data sheets indicate that a thermal storage loses about 10% of its
         # standby energy per day (excluding pipe losses).
         self.thermal_energy_loss_per_day = thermal_energy_loss_per_day
@@ -147,6 +154,17 @@ class ThermalEnergyStorage(Component):
         self.needs_loading = None
         self.raise_on_undersupply = raise_on_undersupply
         self.undersupplied = False
+
+    def _energy_from_temperature(self, temperature):
+        """Usable thermal energy above ``ambient_temperature`` in kWh.
+
+        ``cp`` is given in kJ/(kg·K); the factor 1/3600 converts kJ to kWh.
+        """
+        return self.mass * self.cp * (temperature - self.ambient_temperature) / 3600.0
+
+    def _temperature_from_energy(self, energy_kwh):
+        """Inverse of :meth:`_energy_from_temperature` (kWh -> °C)."""
+        return self.ambient_temperature + energy_kwh * 3600.0 / (self.mass * self.cp)
 
     def operate_storage(self, timestamp, thermal_energy_generator):
         """
@@ -193,19 +211,17 @@ class ThermalEnergyStorage(Component):
         )
         thermal_production = observation["thermal_energy_output"]
 
-        # Formula: E = m * cp * T
-        #     <=> T = E / (m * cp)
-        self.state_of_charge -= (
-            (thermal_energy_demand - thermal_production)
-            * 1000  # kWh to Wh ?? Why?
-            / (60 / self.environment.timebase)
-        )
+        # Energy balance for this timestep, in kWh of usable energy above ambient.
+        # Both the generator output and the demand are power rates [kW] (the
+        # demand profile holds hourly rates sampled at the timestep resolution),
+        # so multiply by the timestep length in hours.
+        timestep_hours = self.environment.timebase / 60.0
+        self.state_of_charge += (
+            thermal_production - thermal_energy_demand
+        ) * timestep_hours
+        # Standby loss acts on the usable energy above ambient.
         self.state_of_charge *= self.efficiency_per_timestep
-        self.current_temperature = (
-            self.state_of_charge
-#            * 3600  # kWh to KJ
-            / (self.mass * self.cp)
-        ) - 273.15
+        self.current_temperature = self._temperature_from_energy(self.state_of_charge)
 
         if thermal_energy_generator.is_running:
             el_load = observation["el_demand"]

--- a/vpplib/thermal_energy_storage.py
+++ b/vpplib/thermal_energy_storage.py
@@ -9,8 +9,12 @@ and accounts for thermal energy losses over time. It can be used in conjunction 
 energy generators like heat pumps, heating rods, or combined heat and power units.
 """
 
+import logging
+
 import pandas as pd
 from vpplib.component import Component
+
+logger = logging.getLogger(__name__)
 
 
 class ThermalEnergyStorage(Component):
@@ -61,6 +65,7 @@ class ThermalEnergyStorage(Component):
         identifier=None,
         environment=None,
         initial_temperature=None,
+        raise_on_undersupply=True,
     ):
         """
         Initialize a ThermalEnergyStorage object.
@@ -89,6 +94,11 @@ class ThermalEnergyStorage(Component):
             Start temperature in °C. If None (default), the storage starts at
             ``target_temperature - hysteresis``. The state of charge is derived
             from the resulting current temperature, so both stay consistent.
+        raise_on_undersupply : bool, optional
+            If True (default), ``get_needs_loading`` raises ``ValueError`` when the
+            temperature drops below ``min_temperature`` (backwards compatible). If
+            False, it instead sets ``self.undersupplied = True``, logs a warning
+            and lets the simulation continue.
 
         Notes
         -----
@@ -135,6 +145,8 @@ class ThermalEnergyStorage(Component):
             / (24 * (60 / self.environment.timebase))
         )
         self.needs_loading = None
+        self.raise_on_undersupply = raise_on_undersupply
+        self.undersupplied = False
 
     def operate_storage(self, timestamp, thermal_energy_generator):
         """
@@ -223,15 +235,19 @@ class ThermalEnergyStorage(Component):
         Raises
         ------
         ValueError
-            If the current temperature falls below the minimum allowable temperature,
-            indicating insufficient thermal energy production
-            
+            If the current temperature falls below the minimum allowable
+            temperature and ``raise_on_undersupply`` is True (the default).
+
         Notes
         -----
         The method implements hysteresis control:
         - If temperature <= (target - hysteresis), set needs_loading to True
         - If temperature >= (target + hysteresis), set needs_loading to False
         - Otherwise, maintain the previous state
+
+        If the temperature drops below ``min_temperature`` and
+        ``raise_on_undersupply`` is False, ``self.undersupplied`` is set to True
+        and a warning is logged instead of raising.
         """
         if self.current_temperature <= (
             self.target_temperature - self.hysteresis
@@ -244,9 +260,18 @@ class ThermalEnergyStorage(Component):
             self.needs_loading = False
 
         if self.current_temperature < self.min_temperature:
-            raise ValueError(
-                "Thermal energy production to low to maintain "
-                + "heat storage temperature!"
+            self.undersupplied = True
+            if self.raise_on_undersupply:
+                raise ValueError(
+                    "Thermal energy production to low to maintain "
+                    + "heat storage temperature!"
+                )
+            logger.warning(
+                "%s: thermal energy production too low to maintain the minimum "
+                "temperature (%.2f < %.2f °C).",
+                self.identifier,
+                self.current_temperature,
+                self.min_temperature,
             )
 
         return self.needs_loading

--- a/vpplib/thermal_energy_storage.py
+++ b/vpplib/thermal_energy_storage.py
@@ -60,6 +60,7 @@ class ThermalEnergyStorage(Component):
         unit,
         identifier=None,
         environment=None,
+        initial_temperature=None,
     ):
         """
         Initialize a ThermalEnergyStorage object.
@@ -84,7 +85,11 @@ class ThermalEnergyStorage(Component):
             Unique identifier for the thermal energy storage
         environment : Environment, optional
             Environment object containing simulation parameters and weather data
-            
+        initial_temperature : float, optional
+            Start temperature in °C. If None (default), the storage starts at
+            ``target_temperature - hysteresis``. The state of charge is derived
+            from the resulting current temperature, so both stay consistent.
+
         Notes
         -----
         The storage is initialized at (target_temperature - hysteresis), which is the
@@ -100,7 +105,14 @@ class ThermalEnergyStorage(Component):
         # Configure attributes
         self.identifier = identifier
         self.target_temperature = target_temperature
-        self.current_temperature = target_temperature - hysteresis
+        # Default start temperature is the lower hysteresis threshold; callers may
+        # override it via ``initial_temperature`` (state_of_charge is derived from
+        # current_temperature below, so it stays consistent).
+        self.current_temperature = (
+            target_temperature - hysteresis
+            if initial_temperature is None
+            else initial_temperature
+        )
         self.min_temperature = min_temperature
         self.timeseries = pd.DataFrame(
             columns=["temperature"],

--- a/vpplib/thermal_energy_storage.py
+++ b/vpplib/thermal_energy_storage.py
@@ -40,7 +40,7 @@ class ThermalEnergyStorage(Component):
     mass : float
         Mass of the storage medium in kg
     cp : float
-        Specific heat capacity of the storage medium in J/(kg·K)
+        Specific heat capacity of the storage medium in kJ/(kg·K)
     state_of_charge : float
         Usable thermal energy stored above ``ambient_temperature``, in kWh
     thermal_energy_loss_per_day : float
@@ -82,7 +82,7 @@ class ThermalEnergyStorage(Component):
         mass : float
             Mass of the storage medium in kg
         cp : float
-            Specific heat capacity of the storage medium in J/(kg·K)
+            Specific heat capacity of the storage medium in kJ/(kg·K)
         thermal_energy_loss_per_day : float
             Fraction of thermal energy lost per day (e.g., 0.1 for 10% loss)
         unit : str

--- a/vpplib/user_profile.py
+++ b/vpplib/user_profile.py
@@ -9,9 +9,12 @@ based on building characteristics, weather data, and user preferences. It can be
 simulate different usage patterns for various components in the virtual power plant.
 """
 
+import logging
 import traceback
 import pandas as pd
 import os
+
+logger = logging.getLogger(__name__)
 
 class UserProfile(object):
     """
@@ -449,6 +452,20 @@ class UserProfile(object):
             self.consumerfactor = self.thermal_energy_demand_yearly / (
                 sum(self.h_del["h_del"])
             )
+            # h_del is a daily series, so its length is the number of days the
+            # factor is calibrated on. Calibrating on much less than a year scales
+            # the demand so the short window carries the full yearly demand.
+            n_days = len(self.h_del)
+            if n_days < 360:
+                logger.warning(
+                    "consumerfactor was calibrated on only %d day(s): the thermal "
+                    "energy demand is scaled so this short period carries the full "
+                    "yearly demand (%.0f kWh). For a representative short-window "
+                    "simulation, calibrate over a full reference year and pass the "
+                    "resulting consumerfactor to UserProfile.",
+                    n_days,
+                    self.thermal_energy_demand_yearly,
+                )
         return self.consumerfactor
 
     # %%:

--- a/vpplib/wind_power.py
+++ b/vpplib/wind_power.py
@@ -13,7 +13,7 @@ import datetime
 
 import pandas as pd
 
-from .component import Component
+from .component import Component, align_timestamp_tz
 
 
 # windpowerlib imports
@@ -260,11 +260,13 @@ class WindPower(Component):
             ).run_model(self.environment.wind_data)
 
         else:
+            index_tz = self.environment.wind_data.index.tz
             self.ModelChain = ModelChain(
                 self.wind_turbine, **modelchain_data
             ).run_model(
                 self.environment.wind_data[
-                    self.environment.start : self.environment.end
+                    align_timestamp_tz(self.environment.start, index_tz):
+                    align_timestamp_tz(self.environment.end, index_tz)
                 ]
             )
 


### PR DESCRIPTION
Fixes a set of bugs uncovered while wiring the components into a dashboard.
Every fix ships with an offline unit test; existing integration tests pass with
no regression, and all 14 `examples/` scripts run to completion.

## Simulation control
- **Ramp logic** (`HeatPump`, `HeatingRod`, `CombinedHeatAndPower`): the ramp
  validators set `is_running` as a side effect and returned `None`, so the
  explicit assignment in `ramp_up`/`ramp_down` was dead code; `last_ramp_up`/
  `last_ramp_down` were only set in `__init__` and never updated, so
  `min_runtime`/`min_stop_time` had no effect. Validators are now pure predicates
  returning a bool; `ramp_up`/`ramp_down` set the running state and update
  `last_ramp_*` on an actual switch.
- **`observations_for_timestamp`** (`HeatPump`, `HeatingRod`): only used the
  controlled path (`is_running` → `el_power * cop`) when the timeseries cell was
  `NaN`, otherwise it returned the pre-filled (uncontrolled) demand value. After
  `prepare_time_series()` this made `operate_storage` unable to ever charge a
  storage (output capped at demand). The running/idle decision now always drives
  the observation.
- **`HeatPump` integer branch**: `observations_for_timestamp` did
  `mean_temp_quarter_hours.temperature.iloc[t]["temperature"]`, indexing a scalar
  with a label. Removed the extra lookup to match the timestamp branch.

## ThermalEnergyStorage
- **Physical state of charge / standby loss**: `state_of_charge` stored the
  absolute enthalpy `mass * cp * (T + 273.15)` and the daily loss was applied to
  that absolute value, draining the store far too fast (~0.45 °C/step standby at
  55 °C). It now holds the **usable** energy above a configurable
  `ambient_temperature` (default 20 °C) in kWh; the standby loss acts on that
  usable energy; demand and production are treated consistently as power rates
  over the timestep. Standby loss drops to a realistic ~0.06 °C/step.
- **`initial_temperature`** parameter: setting `current_temperature` after
  construction left `state_of_charge` stale; an optional `initial_temperature`
  sets both consistently (default keeps prior behaviour).
- **`raise_on_undersupply`** (default `True`, backwards compatible):
  `get_needs_loading` raised `ValueError` when the temperature fell below
  `min_temperature`, aborting the whole simulation. With `False` it sets
  `self.undersupplied`, logs a warning and continues.

## HeatingRod ↔ storage / UserProfile
- **`HeatingRod`** snake_case compatibility: `operate_storage` expects the same
  snake_case API as `HeatPump`/`CombinedHeatAndPower` (`is_running`,
  `ramp_up`/`ramp_down`, `observations_for_timestamp` with a
  `thermal_energy_output` key). `HeatingRod` only offered camelCase and returned
  `heat_output`, so it could not charge a storage. Added a thin compatibility
  layer (the camelCase API is kept), plus a snake `prepare_time_series` alias
  (a snake call previously hit the base-class stub and set `timeseries = []`).
- **`UserProfile`**: `get_thermal_energy_demand` scales demand so the
  calibration period carries the full yearly demand; calibrating on e.g. one
  week silently inflates demand ~52×. `get_consumerfactor` now logs a warning
  when the calibration window is shorter than ~a year (and no pre-calibrated
  `consumerfactor` was supplied).

## BatteryElectricVehicle
- **`set_at_home`**: `random.randrange(0, len(x) - 1)` crashed for single-entry
  trip lists (empty range) and never selected the last entry. Use
  `random.randrange(len(x))`.

## Timezone handling
- The recent timestamp-awareness refactoring made DWD-derived indices tz-aware
  but left several `.loc[start:end]` slices and lookups using tz-naive
  `environment.start`/`end`, raising "Cannot compare tz-naive and tz-aware
  datetime-like objects" (or a `KeyError`).
- Added a shared `align_timestamp_tz` helper in `component.py` and applied it to:
  `Photovoltaic.prepare_time_series`, `WindPower` (weather-data slices),
  `HeatPump.prepare_time_series` and `HeatingRod.prepareTimeSeries`
  (`timeseries_year` slices), and the baseload lookup in
  `Operator.run_base_scenario`.

## Examples
- `examples/demo_installation.py`: printed Unicode check marks that crashed on a
  non-UTF-8 (Windows cp1252) console; reconfigure stdout to UTF-8 if possible.

## Testing
- New offline unit tests (`pytest -m "not integration"`), covering each fix
  including a HeatingRod-charges-a-storage end-to-end and a tz-aware-slice case.
- Integration tests for the affected components pass with no regression; all 14
  `examples/` scripts run to completion.